### PR TITLE
Adding initial version of incident_core for public review

### DIFF
--- a/extension-definition-specifications/incident-core/examples/incident_asset_context.json
+++ b/extension-definition-specifications/incident-core/examples/incident_asset_context.json
@@ -1,0 +1,123 @@
+[
+    {
+        "id": "extension-definition--ef765651-680c-498d-9894-99799f2fa126",
+        "type": "extension-definition",
+        "spec_version": "2.1",
+        "name": "DC3 Incident Core Extension",
+        "description": "A core extension of the Incident object to allow core details of the Incident to be shared while tracking major details tied to the incident's timeline.  Multiple Incidents can be tied together via relationships if a higher degree of fidelity is needed across phases.",
+        "created": "2020-10-19T20:51:00.000Z",
+        "modified": "2021-07-30T16:00:00.000Z",
+        "created_by_ref": "identity--24c6ec5e-0db6-4029-b98e-cb87303c942d",
+        "schema": "https://github.com/oasis-open/cti-stix-common-objects/tree/master/extension-definition-specifications/incident-core",
+        "version": "0.2.1",
+        "extension_types": [ "property-extension" ]
+    },
+    {
+        "type": "incident",
+        "id": "incident--200de3e1-6545-4d21-80b0-ded3570ec7d8",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified":"2020-10-19T01:01:01.000Z",
+        "created_by_ref": "identity--2242662b-d581-4864-8696-fff719dc0500",
+        "spec_version": "2.1",
+        "name": "Exchange Server Compromise",
+        "description": "An Exchange server was compromised",
+        "recoverability": "regular",
+        "mitigation": "Stand up new Exchange server, migrate data store",
+        "extensions": {
+            "extension-definition--ef765651-680c-498d-9894-99799f2fa126": {
+                "extension_type": "property-extension",
+                "defender_activities": [
+                    {
+                        "type": "discovery",
+                        "time": "2021-02-15T01:01:01.000Z"
+                    }
+                ],
+                "detection_methods": ["automated-tool"],
+                "incident_types": ["unauthorized-release"],
+                "criticality": "critical",
+                "functional_impact": "significant",
+                "information_impacts": [
+                    {
+                        "type": "phi",
+                        "impact": "suspected"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "type": "identity",
+        "spec_version": "2.1",
+        "id": "identity--a52b3918-1819-454b-8e6a-42cf18a06c0b",
+        "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "name": "Victim Corp",
+        "sectors": ["defense", "construction"],
+        "identity_class": "organization"
+    },
+    {
+        "type": "asset",
+        "spec_version": "2.1",
+        "id": "asset-1c69a97c-bcfa-4674-b3a2-bfb8f797b7e5",
+        "created": "2021-03-26T01:01:01.000Z",
+        "modified": "2021-03-26T01:01:01.000Z",
+        "name": "Victim Corp Exchange Exchange Server",
+        "cpe": "a:microsoft:exchange_server:2016:cumulative_update_9",
+        "infrastructure_types": ["non-malicious"]
+    },
+    {
+        "type": "vulnerability",
+        "spec_version": "2.1",
+        "id": "vulnerability-c8e2c77a-0369-47a3-831e-e851bd634028",
+        "created": "2021-03-26T01:01:01.000Z",
+        "modified": "2021-03-26T01:01:01.000Z",
+        "name": "CVE-2021-26855",
+        "external_references": [
+            {
+                "source_name": "cve",
+                "external_id": "CVE-2021-26855"
+            }
+        ]
+    },
+    {
+        "type": "relationship",
+        "spec_version": "2.1",
+        "id": "relationship--b76aa1ba-520a-4f71-b451-0c920305b180",
+        "created": "2021-03-26T01:01:01.000Z",
+        "modified": "2021-03-26T01:01:01.000Z",
+        "relationship_type": "owns",
+        "source_ref": "identity--a52b3918-1819-454b-8e6a-42cf18a06c0b",
+        "target_ref": "asset-1c69a97c-bcfa-4674-b3a2-bfb8f797b7e5"
+    },
+    {
+        "type": "relationship",
+        "spec_version": "2.1",
+        "id": "relationship--fd3aa181-2ad6-4822-821d-b7e4dd42c19d",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "relationship_type": "targets",
+        "source_ref": "incident--200de3e1-6545-4d21-80b0-ded3570ec7d8",
+        "target_ref": "identity--a52b3918-1819-454b-8e6a-42cf18a06c0b"
+    },
+    {
+        "type": "relationship",
+        "spec_version": "2.1",
+        "id": "relationship--6a0d7534-39ac-4a04-aab7-7774db1a57d6",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "relationship_type": "impacts",
+        "source_ref": "incident--200de3e1-6545-4d21-80b0-ded3570ec7d8",
+        "target_ref": "asset-1c69a97c-bcfa-4674-b3a2-bfb8f797b7e5"
+    },
+    {
+        "type": "relationship",
+        "spec_version": "2.1",
+        "id": "relationship--e509fe36-6dcd-4b78-8bd2-60dd6788ab55",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "relationship_type": "has",
+        "source_ref": "asset-1c69a97c-bcfa-4674-b3a2-bfb8f797b7e5",
+        "target_ref": "vulnerability-c8e2c77a-0369-47a3-831e-e851bd634028"
+    }
+]

--- a/extension-definition-specifications/incident-core/examples/incident_sample_activity.json
+++ b/extension-definition-specifications/incident-core/examples/incident_sample_activity.json
@@ -1,0 +1,61 @@
+{
+    "type": "bundle",
+    "id": "bundle--a34c0c61-e579-4f85-9f11-8488c8daad15",
+    "objects": [
+        {
+            "id": "extension-definition--ef765651-680c-498d-9894-99799f2fa126",
+            "type": "extension-definition",
+            "spec_version": "2.1",
+            "name": "DC3 Incident Core Extension",
+            "description": "A core extension of the Incident object to allow core details of the Incident to be shared while tracking major details tied to the incident's timeline.  Multiple Incidents can be tied together via relationships if a higher degree of fidelity is needed across phases.",
+            "created": "2020-10-19T20:51:00.000Z",
+            "modified": "2021-07-30T16:00:00.000Z",
+            "created_by_ref": "identity--24c6ec5e-0db6-4029-b98e-cb87303c942d",
+            "schema": "https://github.com/oasis-open/cti-stix-common-objects/tree/master/extension-definition-specifications/incident-core",
+            "version": "0.2.1",
+            "extension_types": [ "property-extension" ]
+        },
+        {
+            "type": "incident",
+            "id": "incident--2242662b-d581-4864-8696-fff719dc0500",
+            "created": "2020-10-19T01:01:01.000Z",
+            "modified":"2020-10-19T01:01:01.000Z",
+            "created_by_ref": "identity--2242662b-d581-4864-8696-fff719dc0500",
+            "spec_version": "2.1",
+            "name": "Sample Incident 1",
+            "description": "An where a drive by and phishing were used, but it is unclear which led to a RDP connection / account creation on a domain controller",
+            "extensions": {
+                "extension-definition--ef765651-680c-498d-9894-99799f2fa126": {
+                    "extension_type": "property-extension",
+                    "detection_methods": ["human-review"],
+                    "defender_activities": [
+                        {
+                            "type": "discovery",
+                            "description": "A server admin found a strange account",
+                            "time": "2020-10-15T01:01:01.000Z"
+                        }
+                    ],
+                    "attacker_activities": [
+                        {
+                            "pattern_ref": "attack-pattern--d742a578-d70e-4d0e-96a6-02a9c30204e6",
+                            "description": "Drive-by compromise of a trusted domain was believed to deliver malware, but it is unclear when it was activated"
+                        },
+                        {
+                            "pattern_ref": "attack-pattern--6aac77c4-eaf2-4366-8c13-ce50ab951f38",
+                            "description": "A phishing campaign was attachments was used to attempt to deliver malicious PDFs.  The malware may have already been active by the time a user clicks on this however as it started before the drive by, but also ended after it."
+                        },
+                        {
+                            "pattern_ref": "attack-pattern--51dea151-0898-4a45-967c-3ebee0420484",
+                            "description": "Remote desktop protocol was used to access domain controller"
+                        },
+                        {
+                            "pattern_ref": "attack-pattern--7610cada-1499-41a4-b3dd-46467b68d177",
+                            "description": "A domain account was created to allow remote access using normal means by the attacker",
+                            "end_time": "2020-10-15T00:01:32.700Z"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/extension-definition-specifications/incident-core/examples/incident_sample_infrastructure.json
+++ b/extension-definition-specifications/incident-core/examples/incident_sample_infrastructure.json
@@ -1,0 +1,150 @@
+[
+    {
+        "id": "extension-definition--ef765651-680c-498d-9894-99799f2fa126",
+        "type": "extension-definition",
+        "spec_version": "2.1",
+        "name": "DC3 Incident Core Extension",
+        "description": "A core extension of the Incident object to allow core details of the Incident to be shared while tracking major details tied to the incident's timeline.  Multiple Incidents can be tied together via relationships if a higher degree of fidelity is needed across phases.",
+        "created": "2020-10-19T20:51:00.000Z",
+        "modified": "2021-07-30T16:00:00.000Z",
+        "created_by_ref": "identity--24c6ec5e-0db6-4029-b98e-cb87303c942d",
+        "schema": "https://github.com/oasis-open/cti-stix-common-objects/tree/master/extension-definition-specifications/incident-core",
+        "version": "0.2.1",
+        "extension_types": [ "property-extension" ]
+    },
+    {
+        "type": "incident",
+        "id": "incident--2242662b-d581-4864-8696-fff719dc0500",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified":"2020-10-19T01:01:01.000Z",
+        "created_by_ref": "identity--2242662b-d581-4864-8696-fff719dc0500",
+        "spec_version": "2.1",
+        "name": "Sample Destruction with Unknown Recovery",
+        "description": "Two systems were hit, but we don't know how and are currently trying to find if it can be fixed while preparing to report on it",
+        "extensions": {
+            "extension-definition--ef765651-680c-498d-9894-99799f2fa126": {
+                "extension_type": "property-extension",
+                "defender_activities": [
+                    {
+                        "type": "discovery",
+                        "time": "2020-10-15T01:01:01.000Z"
+                    },
+                    {
+                        "type": "reported",
+                        "time": "2020-10-17T04:42:00.000Z"
+                    },
+                    {
+                        "type": "estimated-recovery-started",
+                        "time": "2030-01-01T04:42:00.000Z"
+                    }
+                ],
+                "detection_methods": ["user-reporting", "message-from-attacker"],
+                "incident_types": ["unauthorized-release", "destructive"],
+                "criticality": "critical",
+                "functional_impact": "none",
+                "information_impacts": [
+                    {
+                        "type": "pii",
+                        "impact": "loss"
+                    }, 
+                    {
+                        "type": "phi",
+                        "impact": "loss"
+                    },
+                    {
+                        "type": "system-data",
+                        "impact": "destruction"
+                    }
+                ],
+                "recoverability": "regular",
+                "observable_refs": ["file--ff0251fc-b70b-4565-8966-9bf57a2779b8", "file--ff0251fc-b70b-4565-8966-9bf57a2779b8"]
+            }
+        }
+    },
+    {
+        "type": "identity",
+        "spec_version": "2.1",
+        "id": "identity--a52b3918-1819-454b-8e6a-42cf18a06c0b",
+        "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "name": "Victim Corp",
+        "sectors": ["defense", "construction"],
+        "identity_class": "organization"
+    },
+    {
+        "type": "threat-actor",
+        "spec_version": "2.1",
+        "id": "threat-actor--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f",
+        "created_by_ref": "identity--f431f809-377b-45e0-aa1c-6a4751cae5ff",
+        "created": "2016-04-06T20:03:48.000Z",
+        "modified": "2016-04-06T20:03:48.000Z",
+        "threat_actor_types": [ "crime-syndicate"],
+        "name": "Evil Org",
+        "description": "The Evil Org threat actor group",
+        "aliases": ["Syndicate 1", "Evil Syndicate 99"],
+        "roles": ["director"],
+        "goals": ["Steal bank money", "Steal credit cards"],
+        "sophistication": "advanced",
+        "resource_level": "team",
+        "primary_motivation": "organizational-gain"
+    },
+    {
+        "type": "infrastructure",
+        "spec_version": "2.1",
+        "id": "infrastructure--d17635b3-0165-43f6-9409-34e11df070be",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "name": "Enterprise Chat App",
+        "infrastructure_types": ["non-malicious"]
+    },
+    {
+        "type": "infrastructure",
+        "spec_version": "2.1",
+        "id": "infrastructure--3f515010-494d-4bd2-94be-12f285e1f19e",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "name": "Electronic Health Record System",
+        "infrastructure_types": ["non-malicious"]
+    },
+    {
+        "type": "relationship",
+        "spec_version": "2.1",
+        "id": "relationship--fd3aa181-2ad6-4822-821d-b7e4dd42c19d",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "relationship_type": "targets",
+        "source_ref": "incident--2242662b-d581-4864-8696-fff719dc0500",
+        "target_ref": "identity--a52b3918-1819-454b-8e6a-42cf18a06c0b"
+    },
+    {
+        "type": "relationship",
+        "spec_version": "2.1",
+        "id": "relationship--fd3aa181-2ad6-4822-821d-b7e4dd42c19d",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "relationship_type": "attributed-to",
+        "source_ref": "incident--2242662b-d581-4864-8696-fff719dc0500",
+        "target_ref": "threat-actor--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f"
+    },
+    {
+        "type": "relationship",
+        "spec_version": "2.1",
+        "id": "relationship--6a0d7534-39ac-4a04-aab7-7774db1a57d6",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "relationship_type": "impacts",
+        "source_ref": "incident--2242662b-d581-4864-8696-fff719dc0500",
+        "target_ref": "infrastructure--d17635b3-0165-43f6-9409-34e11df070be"
+    },
+    {
+        "type": "relationship",
+        "spec_version": "2.1",
+        "id": "relationship--5ff837f4-fd1a-49cd-b64e-e5fcafc0db5d",
+        "created": "2020-10-19T01:01:01.000Z",
+        "modified": "2020-10-19T01:01:01.000Z",
+        "relationship_type": "impacts",
+        "source_ref": "incident--2242662b-d581-4864-8696-fff719dc0500",
+        "target_ref": "infrastructure--3f515010-494d-4bd2-94be-12f285e1f19e"
+    }
+]

--- a/extension-definition-specifications/incident-core/incident_core.json
+++ b/extension-definition-specifications/incident-core/incident_core.json
@@ -1,0 +1,193 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/oasis-open/cti-stix-common-objects/main/extension-definition-specifications/incident-core/incident_core.json",
+    "title": "DC3 Incident Core Extension",
+    "description": "A core extension of the Incident object to allow core details of the Incident to be shared while tracking major details tied to the incident's timeline.  Multiple Incidents can be tied together via relationships if a higher degree of fidelity is needed across phases.",
+    "type": "object",
+    "required": [
+        "extension_type"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "extension_type": {
+            "type": "string",
+            "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
+            "enum": [
+                "property-extension"
+            ]
+        },
+        "determination": {
+            "type": "string",
+            "description": "If the incident has been confirmed or is suspected.",
+            "enum": [
+                "suspected"
+                , "confirmed"
+            ]
+        },
+        "investigation_status": {
+            "type": "string",
+            "description": "The current status of the incident investigation.",
+            "enum": [
+                "new"
+                , "open"
+                , "closed"
+            ],
+            "$comment": "An Incident should be marked as New until some action is taken"
+        },
+        "incident_types": {
+            "type": "array",
+            "description": "This property uses an Open Vocabulary that specifies the type of incident that occurred, if applicable.  This is an open vocabulary and values SHOULD come from the incident-type-ov vocabulary.",
+            "minItems": 1,
+            "items": {
+                "type": "string"
+            },
+            "$comment": "'blocked', 'failed-attempt', 'major', 'under-investigation'; blocked = stopped via affirmative defense, failed-attempt = it didn't succeed but not due to any affirmative defense for example a password guesser failed but was also not rate limited"
+        },
+        "detection_methods": {
+            "type": "array",
+            "description": "A list of strings containing what was used to detect the activity, ex. commercial tool names, techniques associated with proprietary solutions, human review, external sources, or other methods.",
+            "minItems": 1,
+            "items": {
+                "type": "string"
+            }
+        },
+        "criticality": {
+            "type": "string",
+            "description": "How important this incident is to operations",
+            "enum": [
+                "depricated",
+                "non-critical",
+                "critical"
+            ],
+            "$comment": "I think more granularity is needed here, but not sure how this should be broken up"
+        },
+        "functional_impact": {
+            "type": "string",
+            "description": "The functional impact of the incident on operations",
+            "enum": [
+                "none",
+                "minimal",
+                "significant",
+                "denial",
+                "loss-of-control"
+            ],
+            "$comment": "This scale feels weird to me, but I think it is important to break up the criticality of the system from its impact"
+        },
+        "information_impacts": {
+            "type": "array",
+            "description": "If information has been lost, compromised or otherwise corrupted.  Multiple items can be entered here as an incident can include multiple forms of data theft or destruction.",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "$comment": "Open Vocabulary including: 'pii', 'phi', 'proprietary', 'credentials', 'classified-material' from https://us-cert.cisa.gov/incident-notification-guidelines but will also likely draw in other sources"
+                    },
+                    "impact": {
+                        "type": "string",
+                        "enum": ["suspected", "destruction", "loss", "major-loss"]
+                    }
+                }
+            }
+        },
+        "recoverability": {
+            "type": "string",
+            "description": "The scope of impact required to recover from an incident",
+            "enum": [
+                "not-applicable",
+                "regular",
+                "supplemented",
+                "extended",
+                "not-recoverable"
+            ],
+            "$comment": "This is a closed vocabulary: non-applicable is an addition to what is found on https://us-cert.cisa.gov/incident-notification-guidelines for Incident reports that do not have associated recover costs.  For example a phishing email that was detected successfully."
+        },
+        "external_impacts": {
+            "type": "array",
+            "description": "The scope of impact outside of the direct organization",
+            "minItems": 1,
+            "items": {
+                "type": "string"
+            },
+            "$comment": "This will be an open vocabulary including: 'national-security', 'foreign-relations', 'economic', 'public-confidence', 'civil-liberties', 'public-health'"
+        },
+        "mitigation": {
+            "type": "string",
+            "description": "A description of the steps taken to mitigate this incident.  If available this can be further detailed within defender_activity, but this captures a high level narrative of what has been done instead of a more step by step chain of action."
+        },
+        "observable_refs": {
+            "type": "array",
+            "description": "A list of all observed data that was part of this incident",
+            "minItems": 1,
+            "items": {
+                "type": "string",
+                "$ref": "https://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/identifier.json"
+            }
+        },
+        "defender_activities": {
+            "type": "array",
+            "description": "Points in time relevant to the lifecycle of this incident, such as when it was first detected or when the activity first appeared.  Since each entry is a timestamp when recording events with a start end date they should be marked with '-started' or '-completed' as suffixes",
+            "items": {
+                "type": "object",
+                "required": [
+                    "type"
+                    , "time"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "course_of_action_ref": {
+                        "type": "string",
+                        "$ref": "https://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/identifier.json",
+                        "pattern": "^course-of-action--"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "A general type for the timestamp for higher level rollups",
+                        "$comment": "Open-Vocab including: 'recovery-completed', 'recovery-started', 'detected', 'declared', 'earliest', 'escalated', 'first-observed'"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the advesary activity that occurred"
+                    },
+                    "time": {
+                        "$ref": "https://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/timestamp.json",
+                        "description": "When this activity occurred"
+                    }
+                },
+                "$comment": "This was included as an array instead of a series of external relationships because course of action is optional, and will often not be included.  As such it allows defenders to provide timestamps of when they performed general actions without needing to provide an explicit course of action object.  Many events including detection also do not fit the standard Course of Action use case so it is unclear if this would be the desired long-term behavior."
+            }
+        },
+        "attacker_activities": {
+            "type": "array",
+            "description": "A list of attacker focused activities associated with the Incident including information about when these occurred.",
+            "items": {
+                "type": "object",
+                "required": [
+                    "description"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "description": "A description of adversary activity that occurred and in what sequence.  Sequence information defined by the sequence_start and sequence_end properties, not the position in the array.  This allows for indeterminate sequences to be recorded."
+                    },
+                    "pattern_ref": {
+                        "type": "string",
+                        "$ref": "https://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/identifier.json",
+                        "pattern": "^attack-pattern--"
+                    },
+                    "start_time": {
+                        "$ref": "https://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/timestamp.json",
+                        "description": "The date the activity was first recorded.  If this is not present it is assumed to be unknown."
+                    },
+                    "end_time": {
+                        "$ref": "https://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/timestamp.json",
+                        "description": "The date the activity was last recorded.  If this is not present it is assumed to be unknown."
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is adding a proposed 0.2.1 version of a STIX Incident Core property extension for public review and consideration along with several examples of ways this extension can be used for reporting and tracking Incident information.

DC3 does not yet consider this fully stable as only internal testing has been performed against it, and it has not yet completed a public review.