### PR TITLE
adding allOf to PAP schema and adding PAP:CLEAR

### DIFF
--- a/extension-definition-specifications/pap-marking-definition-f8d/STIX-2.1-PAP-marking-definition.adoc
+++ b/extension-definition-specifications/pap-marking-definition-f8d/STIX-2.1-PAP-marking-definition.adoc
@@ -107,6 +107,8 @@ PAP:AMBER
 
 PAP:RED
 
+PAP:CLEAR
+
 |*extensions* (required)
 |[stixtype]#{dictionary_url}[dictionary]#
 |Specifies the PAP marking “color” as an extension dictionary.
@@ -138,7 +140,8 @@ The value of this property *MUST* be [stixliteral]#property-extension#
 white, 
 green,
 amber,
-red
+red,
+clear
 |===
 
 [[marking-definition]]
@@ -169,7 +172,12 @@ a|red
 a|
 ----
 include::examples/pap-red.json[]
-
+----
+a|clear
+[source,json]
+a|
+----
+include::examples/pap-clear.json[]
 ----
 |===
 

--- a/extension-definition-specifications/pap-marking-definition-f8d/examples/pap-clear.json
+++ b/extension-definition-specifications/pap-marking-definition-f8d/examples/pap-clear.json
@@ -1,0 +1,13 @@
+{ 
+    "type": "marking-definition", 
+    "spec_version": "2.1", 
+    "id": "marking-definition--ad15a0cd-55b6-4588-a14c-a66105329b92", 
+    "created": "2022-10-01T00:00:00.000Z", 
+    "name": "PAP:CLEAR",
+    "extensions": {
+        "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
+            "extension_type": "property-extension",
+            "pap": "clear"
+        }
+    }
+}

--- a/extension-definition-specifications/pap-marking-definition-f8d/extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b.json
+++ b/extension-definition-specifications/pap-marking-definition-f8d/extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b.json
@@ -1,251 +1,316 @@
 {
-    "$id": "https://raw.githubusercontent.com/oasis-open/cti-stix-common-objects/main/extension-definition-specifications/pap-marking-definition-f8d/extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b.json",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "pap-marking-definition-extension",
-    "description": "This marking extension was created to apply PAP data markings",
-    "type": "object",
-    "required": [
-      "id",
-      "type",
-      "name",
-      "spec_version",
-      "created",
-      "extensions"
-    ],
-    "properties": {
-      "type": {
-        "type": "string",
-        "description": "The type of this object, which MUST be the literal `marking-definition`.",
-        "enum": [
-          "marking-definition"
-        ]
-      },
-      "spec_version": {
-        "type": "string",
-        "enum": [
-          "2.1"
-        ],
-        "description": "The version of the STIX specification used to represent this object."
-      },
-      "created": {
-        "$ref": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/timestamp.json",
-        "description": "The created property represents the time at which the first version of this Marking Definition object was created."
+  "$id": "https://raw.githubusercontent.com/oasis-open/cti-stix-common-objects/main/extension-definition-specifications/pap-marking-definition-f8d/extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "pap-marking-definition-extension",
+  "description": "This marking extension was created to apply PAP data markings",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/marking-definition.json"
+    },
+    {
+      "required": [
+        "id",
+        "type",
+        "name",
+        "spec_version",
+        "created",
+        "extensions"
+      ]
+    },
+    {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of this object, which MUST be the literal `marking-definition`.",
+          "enum": [
+            "marking-definition"
+          ]
+        },
+        "spec_version": {
+          "type": "string",
+          "enum": [
+            "2.1"
+          ],
+          "description": "The version of the STIX specification used to represent this object."
+        },
+        "created": {
+          "$ref": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/timestamp.json",
+          "description": "The created property represents the time at which the first version of this Marking Definition object was created."
+        }
       }
     },
-    "name": {
-      "type": "string",
-      "description": "A name used to identify the Marking Definition. The value of this property MUST be one of the following: PAP:WHITE, PAP:GREEN, PAP:AMBER, PAP:RED"
-    },
-    "oneOf": [
-      {
-        "$ref": "#/definitions/pap_white"
-      },
-      {
-        "$ref": "#/definitions/pap_green"
-      },
-      {
-        "$ref": "#/definitions/pap_amber"
-      },
-      {
-        "$ref": "#/definitions/pap_red"
+    {
+      "name": {
+        "type": "string",
+        "description": "A name used to identify the Marking Definition. The value of this property MUST be one of the following: PAP:WHITE, PAP:GREEN, PAP:AMBER, PAP:RED, PAP:CLEAR"
       }
-    ],
-    "defs": {
-      "pap_white": {
-        "description": "The marking-definition object representing Permissible Actions Protocol (PAP) White.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "enum": [
-              "marking-definition--a3bea94c-b469-41dc-9cfe-d6e7daba7730" 
-            ]
-          },
-          "name": {
-            "type": "string",
-            "enum": [
-              "PAP:WHITE"
-            ]
-          },
-          "extensions": {
-            "type": "object",
-            "properties": {
-              "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
-                "type": "object",
-                "properties": {
-                  "extension_type": {
-                    "type": "string",
-                    "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
-                    "enum": [
-                      "property-extension"
-                    ]
-                  },
-                  "pap": {
-                    "type": "string",
-                    "enum": [
-                      "white"
-                    ]
-                  }
-                },
-                "required": [
-                  "extension_type",
-                  "pap"
-                ],
-                "additionalProperties": false
-              }
-            },
-            "required": [
-              "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b"
-            ],
-            "additionalProperties": false
-          }
+    },
+    {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/pap_white"
+        },
+        {
+          "$ref": "#/definitions/pap_green"
+        },
+        {
+          "$ref": "#/definitions/pap_amber"
+        },
+        {
+          "$ref": "#/definitions/pap_red"
+        },
+        {
+          "$ref": "#/definitions/pap_clear"
         }
-      },
-      "pap_green": {
-        "description": "The marking-definition object representing Permissible Actions Protocol (PAP) Green.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "enum": [
-              "marking-definition--c43594d1-4b11-4c59-93ab-1c9b14d53ce9"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "enum": [
-              "PAP:GREEN"
-            ]
-          },
-          "extensions": {
-            "type": "object",
-            "properties": {
-              "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
-                "type": "object",
-                "properties": {
-                  "extension_type": {
-                    "type": "string",
-                    "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
-                    "enum": [
-                      "property-extension"
-                    ]
-                  },
-                  "pap": {
-                    "type": "string",
-                    "enum": [
-                      "green"
-                    ]
-                  }
+      ]
+    }
+  ],
+  "defs": {
+    "pap_white": {
+      "description": "The marking-definition object representing Permissible Actions Protocol (PAP) White.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "marking-definition--a3bea94c-b469-41dc-9cfe-d6e7daba7730" 
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "PAP:WHITE"
+          ]
+        },
+        "extensions": {
+          "type": "object",
+          "properties": {
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
+              "type": "object",
+              "properties": {
+                "extension_type": {
+                  "type": "string",
+                  "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
+                  "enum": [
+                    "property-extension"
+                  ]
                 },
-                "required": [
-                  "extension_type",
-                  "pap"
-                ],
-                "additionalProperties": false
-              }
-            },
-            "required": [
-              "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b"
-            ],
-            "additionalProperties": false
-          }
+                "pap": {
+                  "type": "string",
+                  "enum": [
+                    "white"
+                  ]
+                }
+              },
+              "required": [
+                "extension_type",
+                "pap"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b"
+          ],
+          "additionalProperties": false
         }
-      },
-      "pap_amber": {
-        "description": "The marking-definition object representing Permissible Protocol (PAP) Amber.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "enum": [
-              "marking-definition--60f8932b-e51e-4458-b265-a2e8be9a80ab"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "enum": [
-              "PAP:AMBER"
-            ]
-          },
-          "extensions": {
-            "type": "object",
-            "properties": {
-              "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
-                "type": "object",
-                "properties": {
-                  "extension_type": {
-                    "type": "string",
-                    "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
-                    "enum": [
-                      "property-extension"
-                    ]
-                  },
-                  "pap": {
-                    "type": "string",
-                    "enum": [
-                      "amber"
-                    ]
-                  }
+      }
+    },
+    "pap_green": {
+      "description": "The marking-definition object representing Permissible Actions Protocol (PAP) Green.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "marking-definition--c43594d1-4b11-4c59-93ab-1c9b14d53ce9"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "PAP:GREEN"
+          ]
+        },
+        "extensions": {
+          "type": "object",
+          "properties": {
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
+              "type": "object",
+              "properties": {
+                "extension_type": {
+                  "type": "string",
+                  "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
+                  "enum": [
+                    "property-extension"
+                  ]
                 },
-                "required": [
-                  "extension_type",
-                  "pap"
-                ],
-                "additionalProperties": false
-              }
-            },
-            "required": [
-              "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b"
-            ],
-            "additionalProperties": false
-          }
+                "pap": {
+                  "type": "string",
+                  "enum": [
+                    "green"
+                  ]
+                }
+              },
+              "required": [
+                "extension_type",
+                "pap"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b"
+          ],
+          "additionalProperties": false
         }
-      },
-      "pap_red": {
-        "description": "The marking-definition object representing Permissible Actions Protocol (PAP) Red.",
-        "properties": {
-          "id": {
-            "type": "string",
-            "enum": [
-              "marking-definition--740d36e5-7714-4c30-961a-3ae632ceee0e"
-            ]
-          },
-          "name": {
-            "type": "string",
-            "enum": [
-              "PAP:RED"
-            ]
-          },
-          "extensions": {
-            "type": "object",
-            "properties": {
-              "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
-                "type": "object",
-                "properties": {
-                  "extension_type": {
-                    "type": "string",
-                    "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
-                    "enum": [
-                      "property-extension"
-                    ]
-                  },
-                  "pap": {
-                    "type": "string",
-                    "enum": [
-                      "red"
-                    ]
-                  }
+      }
+    },
+    "pap_amber": {
+      "description": "The marking-definition object representing Permissible Protocol (PAP) Amber.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "marking-definition--60f8932b-e51e-4458-b265-a2e8be9a80ab"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "PAP:AMBER"
+          ]
+        },
+        "extensions": {
+          "type": "object",
+          "properties": {
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
+              "type": "object",
+              "properties": {
+                "extension_type": {
+                  "type": "string",
+                  "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
+                  "enum": [
+                    "property-extension"
+                  ]
                 },
-                "required": [
-                  "extension_type",
-                  "pap"
-                ],
-                "additionalProperties": false
-              }
-            },
-            "required": [
-              "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b"
-            ],
-            "additionalProperties": false
-          }
+                "pap": {
+                  "type": "string",
+                  "enum": [
+                    "amber"
+                  ]
+                }
+              },
+              "required": [
+                "extension_type",
+                "pap"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "pap_red": {
+      "description": "The marking-definition object representing Permissible Actions Protocol (PAP) Red.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "marking-definition--740d36e5-7714-4c30-961a-3ae632ceee0e"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "PAP:RED"
+          ]
+        },
+        "extensions": {
+          "type": "object",
+          "properties": {
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
+              "type": "object",
+              "properties": {
+                "extension_type": {
+                  "type": "string",
+                  "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
+                  "enum": [
+                    "property-extension"
+                  ]
+                },
+                "pap": {
+                  "type": "string",
+                  "enum": [
+                    "red"
+                  ]
+                }
+              },
+              "required": [
+                "extension_type",
+                "pap"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "pap_clear": {
+      "description": "The marking-definition object representing Permissible Actions Protocol (PAP) Clear.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "marking-definition--ad15a0cd-55b6-4588-a14c-a66105329b92" 
+          ]
+        },
+        "name": {
+          "type": "string",
+          "enum": [
+            "PAP:CLEAR"
+          ]
+        },
+        "extensions": {
+          "type": "object",
+          "properties": {
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b": {
+              "type": "object",
+              "properties": {
+                "extension_type": {
+                  "type": "string",
+                  "description": "Defined by STIX 2.1 extension definition rules from 'extension-type-enum'.",
+                  "enum": [
+                    "property-extension"
+                  ]
+                },
+                "pap": {
+                  "type": "string",
+                  "enum": [
+                    "clear"
+                  ]
+                }
+              },
+              "required": [
+                "extension_type",
+                "pap"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b"
+          ],
+          "additionalProperties": false
         }
       }
     }
   }
+}

--- a/extension-definition-specifications/pap-marking-definition-f8d/extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b.json
+++ b/extension-definition-specifications/pap-marking-definition-f8d/extension-definition--f8d78575-edfd-406e-8e84-6162a8450f5b.json
@@ -37,13 +37,11 @@
         "created": {
           "$ref": "http://raw.githubusercontent.com/oasis-open/cti-stix2-json-schemas/stix2.1/schemas/common/timestamp.json",
           "description": "The created property represents the time at which the first version of this Marking Definition object was created."
+        },
+        "name": {
+          "type": "string",
+          "description": "A name used to identify the Marking Definition. The value of this property MUST be one of the following: PAP:WHITE, PAP:GREEN, PAP:AMBER, PAP:RED, PAP:CLEAR"
         }
-      }
-    },
-    {
-      "name": {
-        "type": "string",
-        "description": "A name used to identify the Marking Definition. The value of this property MUST be one of the following: PAP:WHITE, PAP:GREEN, PAP:AMBER, PAP:RED, PAP:CLEAR"
       }
     },
     {
@@ -66,7 +64,7 @@
       ]
     }
   ],
-  "defs": {
+  "$definitions": {
     "pap_white": {
       "description": "The marking-definition object representing Permissible Actions Protocol (PAP) White.",
       "properties": {


### PR DESCRIPTION
This PR adds PAP:CLEAR to the examples, schema, and adoc files. It also adds an AllOf clause to the PAP JSON schema. Per conversation with Chris, there may be some differences in the PAP schema in contrast to the CUI schema for a couple reasons. The CUI spec explicitly restricts some items, such as definition_type, while the PAP spec does not. However, both schemas include required elements in the AllOf clause e.g. properties, required, etc. 