### PR TITLE
Fix text corruption in stix-viz-config.json

### DIFF
--- a/extension-definition-specifications/incident-ef7/stix-viz-config.json
+++ b/extension-definition-specifications/incident-ef7/stix-viz-config.json
@@ -1,7 +1,7 @@
 {
     "incident": {
-	"embeddedRelationships": [ [ "extensions.extension-definition—​ef765651-680c-498d-9894-99799f2fa126.events.event_ref", "has_event", true],
-				   [ "extensions.extension-definition—​ef765651-680c-498d-9894-99799f2fa126.tasks.task_ref", "has_task", true]
+	"embeddedRelationships": [ [ "extensions.extension-definition--ef765651-680c-498d-9894-99799f2fa126.events.event_ref", "has_event", true],
+				   [ "extensions.extension-definition--ef765651-680c-498d-9894-99799f2fa126.tasks.task_ref", "has_task", true]
 				 ]
     },
     "event": {


### PR DESCRIPTION
The content of `stix-viz-config.json` was likely pasted in from a word processor which messed it up.  Instead of double dashes in the STIX IDs, the file had U+2014 U+200B, which is an "em dash" and a "zero width space".  This PR straightens out the content.